### PR TITLE
Fixed nginx websocket timeout

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -85,8 +85,8 @@ server {
 		proxy_set_header       Upgrade $http_upgrade;
 		proxy_set_header       Connection $connection_upgrade;
 		proxy_connect_timeout  8s;
-		proxy_read_timeout     5s;
-		proxy_send_timeout     5s;
+		proxy_read_timeout     120s;
+		proxy_send_timeout     120s;
 		proxy_pass             http://cpcontinued_wsgw_server_$1;
 	}
 


### PR DESCRIPTION
because *someone* set the timeout to 5s instead of the needed 60s.